### PR TITLE
Fix conflicting value in disable_ipv6 var.

### DIFF
--- a/roles/cis/tasks/section-07-level-1.yml
+++ b/roles/cis/tasks/section-07-level-1.yml
@@ -116,7 +116,7 @@
 
 - name: 7.3.1 Disable IPv6 Router Advertisements (Not Scored)
   sysctl: name="{{item}}" value=0 ignoreerrors=yes sysctl_set=yes reload=yes state=present
-  when: disable_ipv6 == "no"
+  when: disable_ipv6 == "yes"
   with_items:
     - net.ipv6.conf.all.accept_ra
     - net.ipv6.conf.default.accept_ra
@@ -128,7 +128,7 @@
 
 - name: 7.3.2 Disable IPv6 Redirect Acceptance (Not Scored)
   sysctl: name="{{item}}" value=0 ignoreerrors=yes sysctl_set=yes reload=yes state=present
-  when: disable_ipv6 == "no"
+  when: disable_ipv6 == "yes"
   with_items:
     - net.ipv6.conf.all.accept_redirects
     - net.ipv6.conf.default.accept_redirects
@@ -140,7 +140,7 @@
 
 - name: 7.3.3 Disable IPv6 (Not Scored)
   sysctl: name="{{item}}" value=1 ignoreerrors=yes sysctl_set=yes reload=yes state=present
-  when: disable_ipv6 == "no"
+  when: disable_ipv6 == "yes"
   with_items:
     - net.ipv6.conf.all.disable_ipv6
     - net.ipv6.conf.default.disable_ipv6


### PR DESCRIPTION
Fixed conflicting logic value checks i.e. disable IPv6 only when the value for `disable_ipv6` variable is set to "yes".
